### PR TITLE
Adding Connectivity Monitoring studio inputs

### DIFF
--- a/CloudVision_Studios/Tech_Library_EVPN_VXLAN/Inputs_Connectivity Monitoring.yaml
+++ b/CloudVision_Studios/Tech_Library_EVPN_VXLAN/Inputs_Connectivity Monitoring.yaml
@@ -1,0 +1,104 @@
+path: []
+inputs:
+  hosts:
+    - description: Host A
+      ipAddr: 192.168.0.221
+      name: host_a
+      url: ''
+    - description: Host B
+      ipAddr: 192.168.0.222
+      name: host_b
+      url: ''
+    - description: Host C
+      ipAddr: 192.168.0.223
+      name: host_c
+      url: ''
+    - description: Host D
+      ipAddr: 192.168.0.224
+      name: host_d
+      url: ''
+    - description: Host E
+      ipAddr: 192.168.0.225
+      name: host_e
+      url: ''
+    - description: Host F
+      ipAddr: 192.168.0.226
+      name: host_f
+      url: ''
+    - description: Host G
+      ipAddr: 192.168.0.227
+      name: host_g
+      url: ''
+    - description: Host I
+      ipAddr: 192.168.0.229
+      name: host_i
+      url: ''
+    - description: Host J
+      ipAddr: 192.168.0.230
+      name: host_j
+      url: ''
+    - description: Host K
+      ipAddr: 192.168.0.231
+      name: host_k
+      url: ''
+    - description: Host L
+      ipAddr: 192.168.0.232
+      name: host_l
+      url: ''
+    - description: Host M
+      ipAddr: 192.168.0.233
+      name: host_m
+      url: ''
+    - description: Host N
+      ipAddr: 192.168.0.234
+      name: host_n
+      url: ''
+    - description: Host O
+      ipAddr: 192.168.0.235
+      name: host_o
+      url: ''
+    - description: Host P
+      ipAddr: 192.168.0.236
+      name: host_p
+      url: ''
+    - description: Host Q
+      ipAddr: 192.168.0.237
+      name: host_q
+      url: ''
+    - description: Host R
+      ipAddr: 192.168.0.238
+      name: host_r
+      url: ''
+    - description: Host S
+      ipAddr: 192.168.0.239
+      name: host_s
+      url: ''
+    - description: Host H
+      ipAddr: 192.168.0.228
+      name: host_h
+      url: ''
+  networkConfig:
+    - inputs:
+        config:
+          monitoredHosts:
+            - host: host_a
+            - host: host_b
+            - host: host_c
+            - host: host_d
+            - host: host_e
+            - host: host_f
+            - host: host_g
+            - host: host_h
+            - host: host_i
+            - host: host_j
+            - host: host_k
+            - host: host_l
+            - host: host_m
+            - host: host_n
+            - host: host_o
+            - host: host_p
+            - host: host_q
+            - host: host_r
+            - host: host_s
+      tags:
+        query: 'Hosts:A OR Hosts:B OR Hosts:C '


### PR DESCRIPTION
Adding Connectivity Monitoring studio inputs to do automated end-to-end reachability testing between all hosts