### PR TITLE
Fixed the 'Undefined' object error in no config.

### DIFF
--- a/CloudVision_Studios/RCF Studio/Routing Control Functions (RCF).yaml
+++ b/CloudVision_Studios/RCF Studio/Routing Control Functions (RCF).yaml
@@ -3,8 +3,8 @@
   body:
     value:
       key:
-        studio_id: 7a161847-e603-49e5-904d-dc02fbef0d4e
-        workspace_id: 50d39f21-0cfd-40f2-90cb-a4a75e420b03
+        studio_id: 
+        workspace_id: 
       display_name: Routing Control Functions (RCF)
       description: RCF Code Unit Management
       template:
@@ -26,7 +26,10 @@
                   newL = indentation + l + '\n'
                   res += newL
               return res.rstrip()
-
+          # Corner case: if the root doesn't contain codeUnit and devCodeUnit after importing RCF studio then it won't throw error.
+          if not root:
+            return 
+          
           codeUnitsData = {codeUnit['unitName']:applyIndentation(codeUnit['unitContent'], level=2) for codeUnit in codeUnits}
           deviceToUnits = {devCodeUnit['devices'][0]: devCodeUnit['inputs']['devAssignments']['devAssignedUnits'] for devCodeUnit in devCodeUnits.inputs}
           %>

--- a/CloudVision_Studios/RCF Studio/Routing Control Functions (RCF).yml
+++ b/CloudVision_Studios/RCF Studio/Routing Control Functions (RCF).yml
@@ -9,29 +9,34 @@
       description: RCF Code Unit Management
       template:
         type: TEMPLATE_TYPE_MAKO
-        body: |+
+        body: |
           <%
           # If the developer wants to see the container details of the script. 
           # Default debug setting is False. The info can be seen in `view build details` after clicking `review Workspace`
           debug = False
 
           def applyIndentation(content: str, indent=3, level=0):
-              '''
-              return: formatted multiline strings with indentation
-              '''
-              contentList = content.splitlines()
-              res = ''
-              indentation = ' ' * (indent * level)
-              for l in contentList:
-                  newL = indentation + l + '\n'
-                  res += newL
-              return res.rstrip()
-          # Corner case: if the root doesn't contain codeUnit and devCodeUnit after importing RCF studio then it won't throw error.
-          if not root:
-            return 
-          
-          codeUnitsData = {codeUnit['unitName']:applyIndentation(codeUnit['unitContent'], level=2) for codeUnit in codeUnits}
-          deviceToUnits = {devCodeUnit['devices'][0]: devCodeUnit['inputs']['devAssignments']['devAssignedUnits'] for devCodeUnit in devCodeUnits.inputs}
+            '''
+            return: formatted multiline strings with indentation
+            '''
+            contentList = content.splitlines()
+            res = ''
+            indentation = ' ' * (indent * level)
+            for l in contentList:
+                newL = indentation + l + '\n'
+                res += newL
+            return res.rstrip()
+
+          codeUnitsData = {}
+          deviceToUnits = {}
+          # Collect infos from inputs.
+          try: 
+            codeUnitsData = {codeUnit['unitName']:applyIndentation(codeUnit['unitContent'], level=2) for codeUnit in codeUnits}
+            deviceToUnits = {devCodeUnit['devices'][0]: devCodeUnit['inputs']['devAssignments']['devAssignedUnits'] for devCodeUnit in devCodeUnits.inputs}
+          except:
+            #Corner case: if the root doesn't contain codeUnit and devCodeUnit keys for some reasons (somtime the CVP contains old workspace, and user imports same studio in the new workspace)
+            #             after importing RCF studio then it won't throw an error. In this case, as long as the user can add any value to the inputs, the studio works as normal.
+            pass
           %>
 
           %if debug:


### PR DESCRIPTION
The error was thrown when the root didn't contain the expected collections by re-importing the RCF studio in a different workspace. This scenario is not expected since the root comes with two keys (codeUnits and devCodeUnits) after importing the RCF studio .yml file.

The new fix prevents no config in the studio throwing errors even if the root comes with no keys for some reasons.  

Normal No Config Inputs
<img width="1154" alt="root with keys" src="https://github.com/arista-netdevops-community/CloudVisionPortal-Examples/assets/143632211/bbf0598b-dc79-4cf5-a234-965cdd173a9c">
Error No Config Inputs
<img width="1168" alt="root without keys" src="https://github.com/arista-netdevops-community/CloudVisionPortal-Examples/assets/143632211/003aca8d-82e6-44ec-9023-fc8f4da0b901">