### PR TITLE
Fix: update requirements.txt

### DIFF
--- a/Bulk_Onboarding/requirements.txt
+++ b/Bulk_Onboarding/requirements.txt
@@ -1,4 +1,4 @@
-cvprac==1.4.0
-jsonrpclib==0.2.1
-jsonrpclib_pelix==0.4.3.2
-Requests==2.32.1
+cvprac=>1.4.0
+jsonrpclib=>0.2.1
+jsonrpclib_pelix=>0.4.3.2
+Requests=>2.32.1

--- a/Bulk_Onboarding/requirements.txt
+++ b/Bulk_Onboarding/requirements.txt
@@ -1,3 +1,4 @@
-cvprac==1.3.1
+cvprac==1.4.0
 jsonrpclib==0.2.1
-Requests==2.31.0
+jsonrpclib_pelix==0.4.3.2
+Requests==2.32.1


### PR DESCRIPTION
For python3 jsonrpclib-pelix is required to be able to set the SSL context in the Server object, otherwise you'll get this error:

```sw = jsonrpclib.Server(f"https://{username}:{password}@{dev}/command-api", context=context)
TypeError: ServerProxy.__init__() got an unexpected keyword argument 'context'```